### PR TITLE
Fix bug in decrypter caused by invalid array index notation being used

### DIFF
--- a/lib/junos/common.rb
+++ b/lib/junos/common.rb
@@ -26,7 +26,7 @@ class RouterCrypt::JunOS
     private
 
     def nibble str, len
-      nib, str[0..len-1] = str[0..len-1], ''
+      nib, str[0,len] = str[0,len], ''
       nib.size == len or raise InvalidPW, 'Insufficent amont of characters'
       nib
     end


### PR DESCRIPTION
irb(main):002:0> require 'router_crypt'
=> true
irb(main):003:0> 100.times { p RouterCrypt::JunOS.decrypt RouterCrypt::JunOS.crypt('test is a cool') }
"test is a cool"
"test is a cool"
"test is a cool"
"test is a cool"
"test is a cool"
"test is a cool"
"test is a cool"
RouterCrypt::JunOS::InvalidPW: Insufficent amont of characters
	from /var/lib/gems/2.3.0/gems/router_crypt-0.4.0/lib/junos/common.rb:30:in `nibble'
	from /var/lib/gems/2.3.0/gems/router_crypt-0.4.0/lib/junos/decrypt.rb:12:in `decrypt'
	from (irb):3:in `block in irb_binding'
	from (irb):3:in `times'
	from (irb):3
	from /usr/bin/irb:11:in `<main>'
